### PR TITLE
Updated sponsorship link to River Financial

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,13 +4,13 @@
     <div class="copyright">
       <p>Copyright &copy; {{ site.time | date: '%Y' }}
 
-        SF Bitcoin Devs
+        SF Bitcoin Devs.
 
-        . All rights reserved.<p>
+        All rights reserved.<p>
       <p>Sponsored by
         <span itemscope itemtype="http://schema.org/Corporation">
-          <a itemprop="url" href="https://alto.financial">
-            <span itemprop="name">Alto Financial</span>
+          <a itemprop="url" href="https://river.com">
+            <span itemprop="name">River Financial</span>
           </a>
         </span> and
 


### PR DESCRIPTION
Updated the link in the footer to change the sponsorship from Alto Financial to River Financial in light of the name change. 