### PR TITLE
Add closed Ordinals BIP proposal to Socratic 68

### DIFF
--- a/content/socratic-68.md
+++ b/content/socratic-68.md
@@ -67,6 +67,7 @@ BIPs
 - [BIP Proposal: Output Script Descriptor Annotations](https://github.com/craigraw/bips/blob/descriptorannotations/bip-descriptorannotations.mediawiki)
 - [BIP Proposal: Peer Feature Negotation](https://groups.google.com/g/bitcoindev/c/DFXtbUdCNZE)
 - [BIP Draft: 24 bits for nVersion nonce space instead of 16](https://groups.google.com/g/bitcoindev/c/fCfbi8hy-AE)
+- [BIP Proposal: Ordinals (closed)](https://github.com/bitcoin/bips/pull/1408)
 
 Noteworthy PRs
 --------------


### PR DESCRIPTION
This change adds a reference to the closed Ordinals BIP proposal to the Socratic Seminar 68 discussion document.

**Summary**
Added a new entry to the BIPs section documenting the Ordinals BIP proposal (PR #1408) which has been closed.

**Changes**
- Added reference to [BIP Proposal: Ordinals (closed)](https://github.com/bitcoin/bips/pull/1408) in the BIPs list of the Socratic 68 seminar notes

This addition helps document the discussion and proposal history related to Ordinals within the context of Socratic Seminar 68.